### PR TITLE
Convert evm chains' id to dola evm id

### DIFF
--- a/sui/omnicore/governance_actions/sources/governance_actions.move
+++ b/sui/omnicore/governance_actions/sources/governance_actions.move
@@ -10,6 +10,7 @@ module governance_actions::governance_actions {
     use oracle::oracle::PriceOracle;
     use pool_manager::pool_manager::{Self, PoolManagerInfo};
     use sui::tx_context::TxContext;
+    use user_manager::user_manager::{Self, UserManagerInfo};
     use wormhole::state::State;
     use wormhole_bridge::bridge_core::{Self, CoreState};
     use wormhole_bridge::bridge_pool::{Self, PoolState};
@@ -65,6 +66,26 @@ module governance_actions::governance_actions {
             let external_cap = governance::borrow_external_cap<GovernanceCap>(&mut flash_cap);
             let storage_cap = lending::storage::register_cap_with_governance(external_cap);
             lending::wormhole_adapter::transfer_storage_cap(wormhole_adapater, storage_cap);
+        };
+
+        governance::external_cap_destroy(governance_external_cap, vote, flash_cap);
+    }
+
+    public entry fun vote_register_evm_chain_id(
+        gov: &mut Governance,
+        governance_external_cap: &mut GovernanceExternalCap,
+        vote: &mut VoteExternalCap,
+        user_manager: &mut UserManagerInfo,
+        evm_chain_id: u16,
+        ctx: &mut TxContext
+    ) {
+        let flash_cap = governance::vote_external_cap<GovernanceCap>(gov, governance_external_cap, vote, ctx);
+
+        if (option::is_some(&flash_cap)) {
+            let governance_cap = governance::borrow_external_cap<GovernanceCap>(&mut flash_cap);
+            let user_manager_cap = user_manager::register_cap_with_governance(governance_cap);
+            // todo: chain id should be fixed, initializing multiple evm_chain_id according to the actual situation
+            user_manager::register_evm_chain_id(&user_manager_cap, user_manager, evm_chain_id);
         };
 
         governance::external_cap_destroy(governance_external_cap, vote, flash_cap);

--- a/sui/omnicore/user_manager/sources/user_manager.move
+++ b/sui/omnicore/user_manager/sources/user_manager.move
@@ -60,13 +60,13 @@ module user_manager::user_manager {
         UserManagerCap {}
     }
 
-    public fun register_evm_chain_id(_: &mut UserManagerCap, user_manager: &mut UserManagerInfo, evm_chain_id: u16) {
+    public fun register_evm_chain_id(_: &UserManagerCap, user_manager: &mut UserManagerInfo, evm_chain_id: u16) {
         let evm_chain_ids = &mut user_manager.evm_chain_ids;
         assert!(!vector::contains(evm_chain_ids, &evm_chain_id), EALREADY_EVM_CHAIN);
         vector::push_back(evm_chain_ids, evm_chain_id);
     }
 
-    public fun unregister_evm_chain_id(_: &mut UserManagerCap, user_manager: &mut UserManagerInfo, evm_chain_id: u16) {
+    public fun unregister_evm_chain_id(_: &UserManagerCap, user_manager: &mut UserManagerInfo, evm_chain_id: u16) {
         let evm_chain_ids = &mut user_manager.evm_chain_ids;
         let (is_evm, index) = vector::index_of(evm_chain_ids, &evm_chain_id);
         assert!(is_evm, ENOT_EVM_CHAIN);


### PR DESCRIPTION
 * Use dola evm id 2

  The addresses of all evm chains use a unified evm chain id.
