### PR TITLE
User id starts from 1

### DIFF
--- a/sui/omnicore/user_manager/sources/user_manager.move
+++ b/sui/omnicore/user_manager/sources/user_manager.move
@@ -109,7 +109,7 @@ module user_manager::user_manager {
         let user = process_evm_address(user_manager, user);
         let user_catalog = &mut user_manager.user_address_catalog;
         assert!(!table::contains(&mut user_catalog.user_address_to_user_id, user), EALREADY_EXIST_USER);
-        let dola_user_id = table::length(&user_catalog.user_id_to_addresses);
+        let dola_user_id = table::length(&user_catalog.user_id_to_addresses) + 1;
         table::add(&mut user_catalog.user_address_to_user_id, user, dola_user_id);
         let user_addresses = vector::empty<DolaAddress>();
         vector::push_back(&mut user_addresses, user);


### PR DESCRIPTION
  The user ID starts from 1, leaves 0 to the treasury, and then invokes the treasury's tokens through governance.
